### PR TITLE
Added optional neighbours parameter

### DIFF
--- a/ecco-cloud-utils/ecco_cloud_utils/mapping.py
+++ b/ecco-cloud-utils/ecco_cloud_utils/mapping.py
@@ -10,7 +10,8 @@ import pyresample as pr
 #%%
 def find_mappings_from_source_to_target(source_grid, target_grid,\
                                         target_grid_radius, \
-                                        source_grid_min_L, source_grid_max_L):
+                                        source_grid_min_L, source_grid_max_L, \
+                                        neighbours = 100):
                                     
     #%%
     # source grid, target_grid : area or grid defintion objects from pyresample
@@ -20,6 +21,11 @@ def find_mappings_from_source_to_target(source_grid, target_grid,\
     
     # source_grid_min_l, source_grid_max_L : min and max distances 
     #                            between adjacent source grid cells (m)
+    
+    # neighbours     : Specifies number of neighbours to look for when getting
+    #                  the neighbour info of a cell using pyresample.
+    #                  Default is 100 to limit memory usage.
+    #                  Value given must be a whole number greater than 0
     
     # # of element of the source and target grids
     len_source_grid = source_grid.size
@@ -31,12 +37,16 @@ def find_mappings_from_source_to_target(source_grid, target_grid,\
     # the maximum number of neighbors to consider when doing the bin averaging
     # assuming that we have the largets target grid radius and the smallest
     # source grid length. (upper bound)
-    neighbours = (max_target_grid_radius*2/source_grid_min_L)**2
+    # the ceiling is used to ensure the result is a whole number > 0
+    neighbours_upper_bound = np.ceil((max_target_grid_radius*2/source_grid_min_L)**2)
     
-    # for now hard limit to 100 neighbours
-    if neighbours > 100:
-        print('more than 100 neighbors indicated.  limiting to 100 for memory')
-        neighbours = 100
+    # compare provided and upper_bound value for neighbours.
+    # limit neighbours to the upper_bound if the supplied neighbours value is larger
+    # since you dont need more neighbours than exists within a cell.
+    if neighbours > neighbours_upper_bound:
+        print('using more neighbours than upper bound.  limiting to the upper bound ' \
+              f'of {neighbours_upper_bound} neighbours')
+        neighbours = neighbours_upper_bound
         
    
     ## FIRST FIND THE SET OF SOURCE GRID CELLS THAT FALL WITHIN THE SERACH

--- a/ecco-cloud-utils/ecco_cloud_utils/mapping.py
+++ b/ecco-cloud-utils/ecco_cloud_utils/mapping.py
@@ -45,10 +45,13 @@ def find_mappings_from_source_to_target(source_grid, target_grid,\
     # since you dont need more neighbours than exists within a cell.
     if neighbours > neighbours_upper_bound:
         print('using more neighbours than upper bound.  limiting to the upper bound ' \
-              f'of {neighbours_upper_bound} neighbours')
+              f'of {int(neighbours_upper_bound)} neighbours')
         neighbours = neighbours_upper_bound
         
-   
+    # make sure neighbours is an int for pyresample
+    # neighbours_upper_bound is float, and user input can be float
+    neighbours = int(neighbours)
+    
     ## FIRST FIND THE SET OF SOURCE GRID CELLS THAT FALL WITHIN THE SERACH
     ## RADIUS OF EACH TARGET GRID CELL
     


### PR DESCRIPTION
Added optional neighbours parameter to find_mappings_from_source_to_target() with a default of 100, made neighbours_upper_bound a ceiling of the previously used equation, and added a check to use the upper bound if the supplied neighbours value is larger.