### PR TITLE
Update ECCO-ACCESS metadata references with PODAAC's metadata tweaks

### DIFF
--- a/metadata/ECCOv4r4_metadata_json/ECCOv4r4_common_metadata.json
+++ b/metadata/ECCOv4r4_metadata_json/ECCOv4r4_common_metadata.json
@@ -20,7 +20,7 @@
       "value": "These fields are provided on a regular lat-lon grid. They have been mapped to the regular lat-lon grid from the original ECCO lat-lon-cap 90 (llc90) native model grid."
    },
    {
-      "name": "conventions",
+      "name": "Conventions",
       "type": "s",
       "value": "CF-1.8, ACDD-1.3"
    },
@@ -133,7 +133,7 @@
    {
       "name": "history",
       "type": "s",
-      "value": "Inagural release of an ECCO \"Central Estimate\" solution to PO.DAAC"
+      "value": "Inaugural release of an ECCO \"Central Estimate\" solution to PO.DAAC"
    },
    {
       "name": "institution",
@@ -206,7 +206,7 @@
       "value": "podaac@podaac.jpl.nasa.gov"
    },
    {
-      "name": "publisher_insitution",
+      "name": "publisher_institution",
       "type": "s",
       "value": "PO.DAAC"
    },

--- a/metadata/ECCOv4r4_metadata_json/ECCOv4r4_common_metadata.json
+++ b/metadata/ECCOv4r4_metadata_json/ECCOv4r4_common_metadata.json
@@ -47,15 +47,10 @@
    {
       "name": "creator_url",
       "type": "s",
-      "value": "TBD_DATASET https://doi.org/xxxxx"
+      "value": "https://ecco.jpl.nasa.gov"
    },
    {
       "name": "date_created",
-      "type": "s",
-      "value": "TBD_DATASET"
-   },
-   {
-      "name": "GCMD_keywords",
       "type": "s",
       "value": "TBD_DATASET"
    },
@@ -95,7 +90,7 @@
       "grid_dimension":"2D"
    },
    {
-      "name": "geospatial_bound_crs",
+      "name": "geospatial_bounds_crs",
       "type": "s",
       "value": "EPSG:4326",
       "grid_dimension":"2D"
@@ -198,7 +193,7 @@
    {
       "name": "project",
       "type": "s",
-      "value": "Estimating the Circulation and Climate of the Ocean"
+      "value": "Estimating the Circulation and Climate of the Ocean (ECCO)"
    },
    {
       "name": "publisher_email",
@@ -223,7 +218,7 @@
    {
       "name": "publisher_url",
       "type": "s",
-      "value": "podaac.jpl.nasa.gov"
+      "value": "https://podaac.jpl.nasa.gov"
    },
    {
       "name": "reference",
@@ -273,7 +268,7 @@
    {
       "name": "keywords",
       "type": "s",
-      "value": "ECCO, State Estimate, Estimating the Circulation and Climate of the Ocean, ocean, sea-ice"
+      "value": "ECCO, State Estimate, Estimating the Circulation and Climate of the Ocean"
    }
 ]
 

--- a/metadata/ECCOv4r4_metadata_json/ECCOv4r4_common_metadata.json
+++ b/metadata/ECCOv4r4_metadata_json/ECCOv4r4_common_metadata.json
@@ -221,11 +221,6 @@
       "value": "https://podaac.jpl.nasa.gov"
    },
    {
-      "name": "reference",
-      "type": "s",
-      "value": "DOI TBD"
-   },
-   {
       "name": "references",
       "type": "s",
       "value": "ECCO Consortium, Fukumori, I., Wang, O., Fenty, I., Forget, G., Heimbach, P., & Ponte, R. M. 2020. Synopsis of the ECCO Central Production Global Ocean and Sea-Ice State Estimate (Version 4 Release 4).doi:10.5281/zenodo.3765929"
@@ -258,7 +253,7 @@
    {
       "name": "id",
       "type": "s",
-      "value": "TBD_DATASET"
+      "value": "TBD_DOI"
    },
    {
       "name": "uuid",


### PR DESCRIPTION
I change the values, names of about ten fields in the common metadata references json. Mostly typos. The fixes to the attribute names are important tho, e.g. `geospatial_bound_crs` >> `geospatial_bounds_crs`