### PR TITLE
qsub scripts, now python can take grouping as argument, job monitor scripts

### DIFF
--- a/generating_netcdf/eccov4r4_gen_for_podaac_20201022_PFE_as_func.py
+++ b/generating_netcdf/eccov4r4_gen_for_podaac_20201022_PFE_as_func.py
@@ -886,7 +886,7 @@ def generate_netcdfs(output_freq_code, job_id:int, num_jobs:int, \
         else:
             record_start_time = np.datetime64(times)
                   
-        print('i, tb ', str(cur_ts_i).zfill(4), tb)
+        print('cur_ts, i, tb ', str(cur_ts).zfill(10), str(cur_ts_i).zfill(4), tb)
                     
 
         # loop through variables to load
@@ -1123,7 +1123,7 @@ def generate_netcdfs(output_freq_code, job_id:int, num_jobs:int, \
                  
                 
             # PROVIDE SPECIFIC ENCODING DIRECTIVES FOR EACH COORDINATE
-            print('\n creating coordinate encodings')
+            print('\n... creating coordinate encodings')
             coord_encoding = dict()
             
             for coord in G.coords:
@@ -1147,7 +1147,7 @@ def generate_netcdfs(output_freq_code, job_id:int, num_jobs:int, \
          
             
             # MERGE GCMD KEYWORDS
-            print('\n merging GCMD keywords')
+            print('\n... merging GCMD keywords')
             common_gcmd_keywords = G.keywords.split(',')
             gcmd_keywords_list = set(grouping_gcmd_keywords + common_gcmd_keywords)
             
@@ -1217,7 +1217,7 @@ def generate_netcdfs(output_freq_code, job_id:int, num_jobs:int, \
             
             # make subdirectory for the grouping
             output_dir = output_dir_freq / grouping['filename'] 
-            print('\n.. creating output_dir', output_dir)
+            print('\n... creating output_dir', output_dir)
 
             if not output_dir.exists():
                 try:
@@ -1241,7 +1241,7 @@ def generate_netcdfs(output_freq_code, job_id:int, num_jobs:int, \
 
             # apply podaac metadata based on filename
             print('\n... applying PODAAC metadata')
-            print(podaac_metadata)
+            pprint(podaac_metadata)
             G = apply_podaac_metadata(G, podaac_metadata)
 
             # sort comments alphabetically
@@ -1263,28 +1263,26 @@ def generate_netcdfs(output_freq_code, job_id:int, num_jobs:int, \
 if __name__ == "__main__":
 
     
-
+    
     num_jobs = 364
     job_id =0
-    grouping_to_process = 0
+    grouping_to_process = 3
     #grouping_to_process='by_job'
     time_steps_to_process = 'by_job'
 
 
     print (sys.argv)
     if len(sys.argv) > 1:
-        # when invoked from 'seq' numbers start from 1, so sub 1 to start from 0
         num_jobs = int(sys.argv[1])
     if len(sys.argv) > 2:
-        job_id = int(sys.argv[2])-1
+        job_id = int(sys.argv[2])
     if len(sys.argv) > 3:
-        # subtract 1 from grouping to process
-        grouping_to_process == int(sys.argv[3]-1)
+        grouping_to_process = int(sys.argv[3])
 
     product_type = 'latlon'
     output_freq_code = 'AVG_DAY'
    
-    debug_mode=True
+    debug_mode=False
     
     print('\n\n===================================')
     print('starting python: num jobs, job_id', num_jobs, job_id)
@@ -1303,3 +1301,6 @@ if __name__ == "__main__":
                      grouping_to_process,\
                      time_steps_to_process, \
                      debug_mode)
+        
+    import time
+    time.sleep(10)

--- a/generating_netcdf/gen_lat_lon_V4r4_product_on_NAS.csh
+++ b/generating_netcdf/gen_lat_lon_V4r4_product_on_NAS.csh
@@ -1,0 +1,62 @@
+#PBS -S /bin/tcsh
+#PBS -W group_list=g26113
+#PBS -l select=78:ncpus=4:model=bro
+#PBS -l walltime=02:00:00
+#PBS -q devel
+##PBS -j oe
+### FOR 2D
+##PBS -l select=26:ncpus=12:model=bro
+
+echo "cd into workdir"
+cd $PBS_O_WORKDIR
+
+#https://www.nas.nasa.gov/hecc/resources/pleiades.html
+
+rm -fr run_*
+
+echo "set cpus"
+
+# total number of cpus. 
+# for 2D fields totcpus = 312 (26x12)
+# FOR 3D FIELDS TOTCPUS = 312 (78X4)
+# alternative = 468 (78x6)
+set totcpus = 312
+
+# 28 maximum possible cpus per node on Broadwell
+# for 2D fields cpuspernode = 12
+#set cpuspernode = 12
+# for 3D fields cpuspernode = 4
+# alternative 6
+set cpuspernode = 4
+
+
+echo ${totcpus}
+echo ${cpuspernode}
+
+rm pbs_nodefile
+cat "$PBS_NODEFILE" > pbs_nodefile
+
+# latlon fields have 13 groups
+# 0..8 are 2D
+# 9..12 are 13
+
+set cur_grouping  = 11
+# end grouping (if one grouping, 1+cur_grouping)
+set num_groupings = 12 
+
+set cpu_start = 0
+set cpu_end = `expr $totcpus - 1`
+
+echo "cpu seq: $cpu_start $cpu_end"
+
+while ($cur_grouping < $num_groupings)
+	echo "Current Grouping : $cur_grouping"
+	echo `date`
+		
+	seq ${cpu_start} ${cpu_end} | parallel -j ${cpuspernode} -u --sshloginfile "$PBS_NODEFILE" \
+		"cd $PWD; /bin/tcsh ./invoke_python_podaac.csh ${totcpus} {} ${cur_grouping}"
+	
+	set cur_grouping = `expr $cur_grouping + 1`
+	echo "incremented cur_grouping ${cur_grouping}"
+	echo `date`
+end

--- a/generating_netcdf/invoke_python_podaac.csh
+++ b/generating_netcdf/invoke_python_podaac.csh
@@ -1,21 +1,23 @@
 #!/bin/tcsh -fe
 
-echo "in tcsh script $2"
+#echo "in tcsh script $2"
 
-rm -fr run_*
+# 1 = num jobs
+# 2 = job id
+# 3 = grouping id
+set numjobs  = `printf "%05d" $1`
+set job_id   = `printf "%05d" $2`
+set gid      = `printf "%05d" $3`
 
-mkdir -p run_$1_$3
+mkdir -p run_${numjobs}_${gid}
 
-echo $SHELL  > run_$1_$3/shell_$2
-echo $1     >> run_$1_$3/shell_$2
-echo $2     >> run_$1_$3/shell_$2
-echo `date` >> run_$1_$3/shell_$2
+printenv     > run_${numjobs}_${gid}/env_${job_id}
 
-printenv     > run_$1_$3/env_$2
-
-echo "Executing run $1 $2 on $HOST in $PWD" > run_$1_$3/exec_$2
+echo "Executing run $1 $2 $3 on $HOST in $PWD" > run_${numjobs}_${gid}/exec_${numjobs}_${gid}
+echo `date` >> run_${numjobs}_${gid}/exec_${numjobs}_${gid}
 
 conda activate ecco
 
 echo "invoking python $1 $2 $3"
-python /home5/ifenty/git_repos_others/ECCO-ACCESS/generating_netcdf/eccov4r4_gen_for_podaac_20201022_PFE_as_func.py $1 $2 $3 > run_$1_$3/output_$2
+
+python /home5/ifenty/git_repos_others/ECCO-ACCESS/generating_netcdf/eccov4r4_gen_for_podaac_20201022_PFE_as_func.py $1 $2 $3 > run_${numjobs}_${gid}/output_${job_id}

--- a/generating_netcdf/podaac_how_far_latlon.sh
+++ b/generating_netcdf/podaac_how_far_latlon.sh
@@ -9,38 +9,38 @@ echo " 1. SSH  : $x"
 export x=`find . |grep OCEAN_BOTTOM_PRES |wc -l`
 echo " 2. OBP  : $x"
 
-export x=`find . |grep OCEAN_TEMP | wc -l`
-echo " 3. TS   : $x"
+export x=`find . |grep FW |wc -l`
+echo " 3. FW   : $x"
 
-export x=`find . |grep OCEAN_VEL |wc -l`
-echo " 4. VEL  : $x"
+export x=`find . |grep HEAT |wc -l`
+echo " 4. HEAT : $x"
 
 export x=`find . |grep ATM |wc -l`
 echo " 5. ATM  : $x"
 
-export x=`find . |grep DENS |wc -l`
-echo " 6. DENS : $x"
+export x=`find . |grep MIXED |wc -l`
+echo " 6. MIXED: $x"
 
 export x=`find . |grep STRESS |wc -l`
 echo " 7. STRES: $x"
 
-export x=`find . |grep HEAT |wc -l`
-echo " 8. HEAT : $x"
-
-export x=`find . |grep FW |wc -l`
-echo " 9. FW   : $x"
-
-export x=`find . |grep BOLUS |wc -l`
-echo "10. BOLUS: $x"
-
-export x=`find . |grep MIXED |wc -l`
-echo "11. MIXED: $x"
-
 export x=`find . |grep CONC |wc -l`
-echo "12. CONC : $x"
+echo " 8. CONC : $x"
 
 export x=`find . |grep ICE_VEL |wc -l`
-echo "13. ICEVE: $x"
+echo " 9. ICEVE: $x"
 
-sleep 5
+export x=`find . |grep OCEAN_TEMP | wc -l`
+echo "10. TS   : $x"
+
+export x=`find . |grep DENS |wc -l`
+echo "11. DENS : $x"
+
+export x=`find . |grep OCEAN_VEL |wc -l`
+echo "12. VEL  : $x"
+
+export x=`find . |grep BOLUS |wc -l`
+echo "13. BOLUS: $x"
+
+sleep $1 
 done

--- a/metadata/ECCOv4r4_metadata_json/ECCOv4r4_groupings_for_latlon_datasets.json
+++ b/metadata/ECCOv4r4_metadata_json/ECCOv4r4_groupings_for_latlon_datasets.json
@@ -16,35 +16,6 @@
     "dimension" : "2D"
    },
    {
-    "name" : "ocean potential temperature and salinity",
-    "fields": "THETA, SALT",
-    "product": "latlon",
-    "filename" : "OCEAN_TEMPERATURE_SALINITY",
-    "dimension" : "3D"
-   },
-   {
-    "name": "ocean density, stratification, and hydrostatic pressure",
-    "fields": "RHOAnoma, DRHODR, PHIHYD",
-    "product": "latlon",
-    "filename" : "OCEAN_DENS_STRAT_PRESS",
-    "dimension" : "3D"
-   },
-   {
-    "name": "ocean velocity",
-    "fields": "EVEL, NVEL, WVELMASS",
-    "product": "latlon",
-    "variable_rename" : "WVELMASS:WVEL",
-    "filename" : "OCEAN_VELOCITY",
-    "dimension" : "3D"
-   },
-   {
-    "name": "Gent-McWilliams ocean bolus velocity",
-    "fields": "EVELSTAR, NVELSTAR, WVELSTAR",
-    "product": "latlon",
-    "filename" : "OCEAN_BOLUS_VELOCITY",
-    "dimension" : "3D"
-   },
-   {
     "name": "ocean and sea-ice surface freshwater fluxes",
     "fields": "EXFpreci, EXFevap, EXFroff, SIsnPrcp, EXFempmr, oceFWflx, SIatmFW, SFLUX, SIacSubl, SIrsSubl, SIfwThru",
     "product": "latlon",
@@ -53,7 +24,7 @@
    },
    {
     "name": "ocean and sea-ice surface heat fluxes",
-    "fields": "EXFhl,   EXFhs, EXFlwdn, EXFswdn, EXFqnet, oceQnet, SIatmQnt, TFLUX, EXFswnet, EXFlwnet, oceQsw, SIaaflux",
+    "fields": "EXFhl, EXFhs, EXFlwdn, EXFswdn, EXFqnet, oceQnet, SIatmQnt, TFLUX, EXFswnet, EXFlwnet, oceQsw, SIaaflux",
     "product": "latlon",
     "filename" : "OCEAN_AND_ICE_SURFACE_HEAT_FLUX",
     "dimension" : "2D"
@@ -92,5 +63,34 @@
     "product": "latlon",
     "filename" : "SEA_ICE_VELOCITY",
     "dimension" : "2D"
-   }   
+   },
+   {
+    "name" : "ocean potential temperature and salinity",
+    "fields": "THETA, SALT",
+    "product": "latlon",
+    "filename" : "OCEAN_TEMPERATURE_SALINITY",
+    "dimension" : "3D"
+   },
+   {
+    "name": "ocean density, stratification, and hydrostatic pressure",
+    "fields": "RHOAnoma, DRHODR, PHIHYD",
+    "product": "latlon",
+    "filename" : "OCEAN_DENS_STRAT_PRESS",
+    "dimension" : "3D"
+   },
+   {
+    "name": "ocean velocity",
+    "fields": "EVEL, NVEL, WVELMASS",
+    "product": "latlon",
+    "variable_rename" : "WVELMASS:WVEL",
+    "filename" : "OCEAN_VELOCITY",
+    "dimension" : "3D"
+   },
+   {
+    "name": "Gent-McWilliams ocean bolus velocity",
+    "fields": "EVELSTAR, NVELSTAR, WVELSTAR",
+    "product": "latlon",
+    "filename" : "OCEAN_BOLUS_VELOCITY",
+    "dimension" : "3D"
+   }
 ]

--- a/metadata/ECCOv4r4_metadata_json/ECCOv4r4_groupings_for_native_datasets.json
+++ b/metadata/ECCOv4r4_metadata_json/ECCOv4r4_groupings_for_native_datasets.json
@@ -16,36 +16,6 @@
     "dimension" : "2D"
    },
    {
-    "name" : "ocean potential temperature and salinity",
-    "fields": "THETA, SALT",
-    "product": "native",
-    "filename" : "OCEAN_TEMPERATURE_SALINITY",
-    "dimension" : "3D"
-   },
-   {
-    "name": "ocean density, stratification, and hydrostatic pressure",
-    "fields": "RHOAnoma, DRHODR, PHIHYD, PHIHYDcR",
-    "product": "native",
-    "dataset_description" : "ocean density, stratification, and hydrostatic pressure",
-    "filename" : "OCEAN_DENS_STRAT_PRESS",
-    "dimension" : "3D"
-   },
-   {
-    "name": "ocean velocity",
-    "fields": "UVEL, VVEL, WVELMASS",
-    "product": "native",
-    "variable_rename" : "WVELMASS:WVEL",
-    "filename" : "OCEAN_VELOCITY",
-    "dimension" : "3D"
-   },
-   {
-    "name": "Gent-McWilliams ocean bolus velocity",
-    "fields": "UVELSTAR, VVELSTAR, WVELSTAR",
-    "product": "native",
-    "filename" : "OCEAN_BOLUS_VELOCITY",
-    "dimension" : "3D"
-   },
-   {
     "name": "ocean and sea-ice surface freshwater fluxes",
     "fields": "EXFpreci, EXFevap, EXFroff, SIsnPrcp, EXFempmr, oceFWflx, SIatmFW, SFLUX, SIacSubl, SIrsSubl, SIfwThru",
     "product": "native",
@@ -118,7 +88,7 @@
    },   
    {
     "name": "ocean three-dimensional potential temperature fluxes",
-    "fields":"ADVx_TH, ADVy_TH, DFrE_TH, DFyE_TH, ADVr_TH, DFxE_TH, DFrI_TH",
+    "fields":"ADVx_TH, DFxE_TH, ADVy_TH, DFyE_TH, ADVr_TH, DFrE_TH, DFrI_TH",
     "comment": "ADV*_TH and DF*_TH terms are potential temperature fluxes.",
     "product": "native",
     "filename" : "OCEAN_3D_TEMPERATURE_FLUX",
@@ -126,17 +96,10 @@
    },
    {
     "name": "ocean three-dimensional salinity fluxes",
-    "fields":"ADVx_SLT, ADVy_SLT, DFrE_SLT, DFyE_SLT, ADVr_SLT, DFxE_SLT, DFrI_SLT, oceSPtnd",
+    "fields":"ADVx_SLT, DFxE_SLT, ADVy_SLT, DFyE_SLT, ADVr_SLT, DFrE_SLT, DFrI_SLT, oceSPtnd",
     "comment": "ADV*_SLT and DF*_SLT terms are salinity fluxes. oceSPtnd is salt tendency per unit area (g m-2 s-1), not salinity flux.",
     "product": "native",
     "filename" : "OCEAN_3D_SALINITY_FLUX",
-    "dimension" : "3D"
-   },
-   {
-    "name": "ocean three-dimensional momentum tendency",
-    "fields":"Um_dPHdx, Vm_dPHdy",
-    "product": "native",
-    "filename" : "OCEAN_3D_MOMENTUM_TENDENCY",
     "dimension" : "3D"
    },
    {
@@ -146,5 +109,42 @@
     "product": "native",
     "filename" : "SEA_ICE_PLUME_FLUX",
     "dimension" : "3D"
-   }      
+   },
+   {
+    "name" : "ocean potential temperature and salinity",
+    "fields": "THETA, SALT",
+    "product": "native",
+    "filename" : "OCEAN_TEMPERATURE_SALINITY",
+    "dimension" : "3D"
+   },
+   {
+    "name": "ocean density, stratification, and hydrostatic pressure",
+    "fields": "RHOAnoma, DRHODR, PHIHYD, PHIHYDcR",
+    "product": "native",
+    "dataset_description" : "ocean density, stratification, and hydrostatic pressure",
+    "filename" : "OCEAN_DENS_STRAT_PRESS",
+    "dimension" : "3D"
+   },
+   {
+    "name": "ocean velocity",
+    "fields": "UVEL, VVEL, WVELMASS",
+    "product": "native",
+    "variable_rename" : "WVELMASS:WVEL",
+    "filename" : "OCEAN_VELOCITY",
+    "dimension" : "3D"
+   },
+   {
+    "name": "Gent-McWilliams ocean bolus velocity",
+    "fields": "UVELSTAR, VVELSTAR, WVELSTAR",
+    "product": "native",
+    "filename" : "OCEAN_BOLUS_VELOCITY",
+    "dimension" : "3D"
+   },
+   {
+    "name": "ocean three-dimensional momentum tendency",
+    "fields":"Um_dPHdx, Vm_dPHdy",
+    "product": "native",
+    "filename" : "OCEAN_3D_MOMENTUM_TENDENCY",
+    "dimension" : "3D"
+   }
 ]


### PR DESCRIPTION
added working qsub scripts (invoke with qsub -S /bin/tcsh gen_lat_lon_V4r4_product_on_NAS.csh), changed order of dataset groupings (2D first, then 3D), added script to monitor progress of dataset production (podaac_how_far_latlon), and updated the actual generation python routine again.  Now the code can be called with a particular group and determine which time steps to process based on num_jobs and job_id