### PR TITLE
Correct one more typo

### DIFF
--- a/metadata/ECCOv4r4_metadata_json/ECCOv4r4_global_metadata_for_all_datasets.json
+++ b/metadata/ECCOv4r4_metadata_json/ECCOv4r4_global_metadata_for_all_datasets.json
@@ -194,7 +194,7 @@
    {
       "name": "product_time_coverage_end",
       "type": "s",
-      "value": "2018-01-00T00:00:00"
+      "value": "2018-01-01T00:00:00"
    },
    {
       "name": "product_time_coverage_start",


### PR DESCRIPTION
2018-01-0**0**T00:00:00 in ECCOv4r4_global_metadata_for_all_datasets.json should be 2018-01-0**1**T00:00:00.