### PR TITLE
rewrote long names and comments for k_l, k_u, Z* to reflect correct u…

### DIFF
--- a/metadata/ECCOv4r4_metadata_json/ECCOv4r4_coordinate_metadata_for_native_datasets.json
+++ b/metadata/ECCOv4r4_metadata_json/ECCOv4r4_coordinate_metadata_for_native_datasets.json
@@ -63,15 +63,15 @@
    },
    {
       "name": "k_l",
-      "long_name": "grid index in z for variables at lower 'w' location",
-      "comment": "First index corresponds to 'w' location at the bottom of the uppermost model tracer cell.",
+      "long_name": "grid index in z corresponding to the top face of tracer grid cells ('w' locations)",
+      "comment": "First index corresponds to the top face of the uppermost tracer grid cell. The use of 'l' in the variable name follows the MITgcm convention for naming the top face of ocean tracer grid cells.",
       "grid_dimension": "3D",
       "coverage_content_type": "coordinate"
    },   
    {
       "name": "k_u",
-      "long_name": "grid index in z for variables at upper 'w' location",
-      "comment": "First index corresponds to 'w' location at the top of the uppermost model tracer cell.",
+      "long_name": "grid index in z corresponding to the bottom face of tracer grid cells ('w' locations)",
+      "comment": "First index corresponds to the bottom face of the uppermost tracer grid cell. The use of 'u' in the variable name follows the MITgcm convention for naming the bottom face of ocean tracer grid cells.",
       "grid_dimension": "3D",
       "coverage_content_type": "coordinate"
    },   
@@ -154,7 +154,7 @@
    },
    {
       "name": "Z_bnds",
-      "long_name": "depths of tracer grid cell upper and lower interfaces",
+      "long_name": "depths of top and bottom faces of tracer grid cell",
       "comment": "One pair of depths for each vertical level.",
       "units": "m",
       "positive" : "up",
@@ -164,8 +164,8 @@
    {
       "name": "Zp1",
       "standard_name": "depth",
-      "long_name": "depth of tracer grid cell interface",
-      "comment": "Contains one element more than the number of vertical layers. First element is 0m, the depth of the upper interface of the surface grid cell. Last element is the depth of the lower interface of the deepest grid cell.",
+      "long_name": "depth of top/bottom face of tracer grid cell",
+      "comment": "Contains one element more than the number of vertical layers. First element is 0m, the depth of the top face of the uppermost grid cell. Last element is the depth of the bottom face of the deepest grid cell.",
       "units": "m",
       "positive" : "up",
       "grid_dimension":"3D",
@@ -174,8 +174,8 @@
    {
       "name": "Zu",
       "standard_name": "depth",
-      "long_name": "depth of tracer grid cell upper interface",
-      "comment": "First element is 0m, the depth of the upper interface of the surface grid cell. Last element is the depth of the upper interface of the deepest grid cell.",
+      "long_name": "depth of bottom face of tracer grid cell",
+      "comment": "First element is -10m, the depth of the bottom face of the uppermost tracer grid cell. Last element is the depth of the bottom face of the deepest grid cell. The use of 'u' in the variable name follows the MITgcm convention for naming the bottom face of ocean tracer grid cells.",
       "units": "m",
       "positive" : "up",
       "grid_dimension":"3D",
@@ -184,8 +184,8 @@
    {
       "name": "Zl",
       "standard_name": "depth",
-      "long_name": "depth of tracer grid cell lower interface",
-      "comment": "First element is 10m, the depth of lower interface of the surface grid cell. Last element is the depth of the lower interface of the deepest grid cell.",
+      "long_name": "depth of top face of tracer grid cell",
+      "comment": "First element is 0m, the depth of the top face of the uppermost tracer grid cell (i.e., the ocean surface). Last element is the depth of the top face of the deepest grid cell. The use of 'l' in the variable name follows the MITgcm convention for naming the top face of ocean tracer grid cells.",
       "units": "m",
       "positive" : "up",
       "grid_dimension":"3D",


### PR DESCRIPTION
rewrote long names and comments for k_l, k_u, Z* to reflect correct understanding of 'l' and 'u' in MITgcm ocean variable naming